### PR TITLE
Fix: Underscore redirects not working

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,66 @@ server {
 #     return 301 $scheme://sfucsss.org$request_uri;
 # }
 
+# TODO: Uncomment me once the A record points to this VPS
+# server {
+    # server_name test.sfucsss.org;
+    # listen 80;
+    #
+    # root /var/www/html;
+    #
+    # access_log /var/www/logs/csss-site-backend/nginx-access.log;
+    # error_log /var/www/logs/csss-site-backend/nginx-error.log;
+    #
+    # error_page 404 /404.html;
+    #
+    # # proxy csss-site-backend
+    # location /api/ {
+    #     rewrite ^/api/(.*)$ /$1 break;
+    #
+    #     keepalive_timeout 5;
+    #     client_max_body_size 1G; # Was 4G
+    #
+    #     proxy_set_header Host $host;
+    #     proxy_set_header X-Real-IP $remote_addr;
+    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #     proxy_set_header X-Forwarded-Proto $scheme;
+    #     proxy_pass http://backend;
+    #
+    #     # update cors header to allow requests from test site
+    #     add_header Access-Control-Allow-Origin https://test.sfucsss.org always;
+    #     add_header Access-Control-Allow-Credentials true;
+    # }
+    #
+    # # Events had a URL scheme like `sfucsss.org/events/<event>/<year>[/page]`
+    # # We want to redirect them to `<event>.sfucsss.org/<year>[/page]`
+    # location ~ "^/events/(mm|mountain_madness)/(?<year>\d{4})(?<page>/.*)$" {
+    #     return 301 https://madness.sfucsss.org/$year$page;
+    # }
+    #
+    # # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
+    # location ~ "^/events/(?<event>tech_fair|fall_hacks)/(?<year>\d{4})(?<page>/.*)?$" {
+    #     set $new_event "";
+    #     if ($event = "tech_fair") {
+    #         set $new_event "tech-fair";
+    #     }
+    #     if ($event = "fall_hacks") {
+    #         set $new_event "fall-hacks";
+    #     }
+    #     return 301 /events/$new_event/$year$page;
+    # }
+    #
+    # # for the rest of the subdomains
+    # location ~ "^/events/(?<event>frosh|tech-fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
+    #     return 301 https://$event.sfucsss.org/$year$page;
+    # }
+    #
+    # # No 404 page since that will be handled by Angular
+    # location / {
+    #     charset utf-8;
+    #     try_files $uri $uri/ index.html;
+    # }
+# }
+
 # serves the test version of the site
 # suitable for testing new deployments
 server {
@@ -86,7 +146,7 @@ server {
     }
 
     # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
-    location ~ "^/events/(?<event>tech-fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
+    location ~ "^/events/(?<event>tech_fair|fall_hacks)/(?<year>\d{4})(?<page>/.*)?$" {
         set $new_event "";
         if ($event = "tech_fair") {
             set $new_event "tech-fair";
@@ -104,7 +164,7 @@ server {
 
     location / {
         charset utf-8;
-        try_files $uri $uri/ $uri.html $uri/index.html =404;
+        try_files $uri $uri/ index.html;
     }
 }
 
@@ -210,6 +270,7 @@ server {
 #     }
 # }
 
+# TODO: Comment this block out if there are no pages under construction.
 # For pages under construction
 server {
     server_name www.sfucsss.org sfucsss.org;

--- a/nginx.conf
+++ b/nginx.conf
@@ -74,7 +74,7 @@ server {
     #     proxy_pass http://backend;
     #
     #     # update cors header to allow requests from test site
-    #     add_header Access-Control-Allow-Origin https://test.sfucsss.org always;
+    #     add_header Access-Control-Allow-Origin https://sfucsss.org always;
     #     add_header Access-Control-Allow-Credentials true;
     # }
     #


### PR DESCRIPTION
* Fixed the pattern matching on the old URLs that had underscores in the event title.
* Added a server block and instructions on when to uncomment it