### PR TITLE
Feature: Angular Migration patch

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,171 +2,71 @@ upstream backend {
     server unix:/var/www/gunicorn.sock fail_timeout=0;
 }
 
-server {
-    server_name new.sfucsss.org;
-    listen 80;
-
-    root /var/www/html;
-
-    access_log /var/www/logs/csss-site-backend/nginx-access.log;
-    error_log /var/www/logs/csss-site-backend/nginx-error.log;
-
-    # proxy csss-site-backend
-    location /api/ {
-        rewrite ^/api/(.*)$ /$1 break;
-
-        keepalive_timeout 5;
-        client_max_body_size 1G; # Was 4G
-
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_pass http://backend;
-
-        add_header Access-Control-Allow-Origin https://new.sfucsss.org always;
-        add_header Access-Control-Allow-Credentials true;
-    }
-
-    # redirects old 2024 mountain madness requests to the new URL
-    location ~ ^/events/2024/mm(/|/index.html)?$ {
-        return 301 /mountain_madness/2024/index.html;
-    }
-
-    # any other matching path
-    location / {
-        charset utf-8;
-        try_files $uri $uri/ $uri/index.html =404;
-    }
-}
-
-# TODO: When redirecting sfucsss.org to the Angular rewrite, delete the other new.sfucsss.org block and uncomment this one.
 # Redirect from the first rewrite to the Angular rewrite
-# server {
-#     server_name www.new.sfucsss.org new.sfucsss.org;
-#     listen 80;
-#     return 301 $scheme://sfucsss.org$request_uri;
-# }
-
-# TODO: Uncomment me once the A record points to this VPS
-# server {
-    # server_name test.sfucsss.org;
-    # listen 80;
-    #
-    # root /var/www/html;
-    #
-    # access_log /var/www/logs/csss-site-backend/nginx-access.log;
-    # error_log /var/www/logs/csss-site-backend/nginx-error.log;
-    #
-    # error_page 404 /404.html;
-    #
-    # # proxy csss-site-backend
-    # location /api/ {
-    #     rewrite ^/api/(.*)$ /$1 break;
-    #
-    #     keepalive_timeout 5;
-    #     client_max_body_size 1G; # Was 4G
-    #
-    #     proxy_set_header Host $host;
-    #     proxy_set_header X-Real-IP $remote_addr;
-    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #     proxy_set_header X-Forwarded-Proto $scheme;
-    #     proxy_pass http://backend;
-    #
-    #     # update cors header to allow requests from test site
-    #     add_header Access-Control-Allow-Origin https://sfucsss.org always;
-    #     add_header Access-Control-Allow-Credentials true;
-    # }
-    #
-    # # Events had a URL scheme like `sfucsss.org/events/<event>/<year>[/page]`
-    # # We want to redirect them to `<event>.sfucsss.org/<year>[/page]`
-    # location ~ "^/events/(mm|mountain_madness)/(?<year>\d{4})(?<page>/.*)$" {
-    #     return 301 https://madness.sfucsss.org/$year$page;
-    # }
-    #
-    # # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
-    # location ~ "^/events/(?<event>tech_fair|fall_hacks)/(?<year>\d{4})(?<page>/.*)?$" {
-    #     set $new_event "";
-    #     if ($event = "tech_fair") {
-    #         set $new_event "tech-fair";
-    #     }
-    #     if ($event = "fall_hacks") {
-    #         set $new_event "fall-hacks";
-    #     }
-    #     return 301 /events/$new_event/$year$page;
-    # }
-    #
-    # # for the rest of the subdomains
-    # location ~ "^/events/(?<event>frosh|tech-fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
-    #     return 301 https://$event.sfucsss.org/$year$page;
-    # }
-    #
-    # # No 404 page since that will be handled by Angular
-    # location / {
-    #     charset utf-8;
-    #     try_files $uri $uri/ index.html;
-    # }
-# }
-
-# serves the test version of the site
-# suitable for testing new deployments
 server {
-    server_name test.sfucsss.org;
+    server_name www.new.sfucsss.org new.sfucsss.org;
     listen 80;
-
-    root /var/www/test-sfucsss;
-
-    access_log /var/www/logs/csss-site-backend/test-nginx-access.log;
-    error_log /var/www/logs/csss-site-backend/test-nginx-error.log;
-
-    error_page 404 /404.html;
-
-    # proxy csss-site-backend
-    location /api/ {
-        rewrite ^/api/(.*)$ /$1 break;
-
-        keepalive_timeout 5;
-        client_max_body_size 1G; # Was 4G
-
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_pass http://backend;
-
-        # update cors header to allow requests from test site
-        add_header Access-Control-Allow-Origin https://test.sfucsss.org always;
-        add_header Access-Control-Allow-Credentials true;
-    }
-
-    # Events had a URL scheme like `sfucsss.org/events/<event>/<year>[/page]`
-    # We want to redirect them to `<event>.sfucsss.org/<year>[/page]`
-    location ~ "^/events/(mm|mountain_madness)/(?<year>\d{4})(?<page>/.*)$" {
-        return 301 https://madness.sfucsss.org/$year$page;
-    }
-
-    # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
-    location ~ "^/events/(?<event>tech_fair|fall_hacks)/(?<year>\d{4})(?<page>/.*)?$" {
-        set $new_event "";
-        if ($event = "tech_fair") {
-            set $new_event "tech-fair";
-        }
-        if ($event = "fall_hacks") {
-            set $new_event "fall-hacks";
-        }
-        return 301 /events/$new_event/$year$page;
-    }
-
-    # for the rest of the subdomains
-    location ~ "^/events/(?<event>frosh|tech-fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
-        return 301 https://$event.sfucsss.org/$year$page;
-    }
-
-    location / {
-        charset utf-8;
-        try_files $uri $uri/ index.html;
-    }
+    return 301 $scheme://sfucsss.org$request_uri;
 }
+
+# suitable for testing new deployments
+# server {
+#     server_name test.sfucsss.org;
+#     listen 80;
+#
+#     root /var/www/test-sfucsss;
+#
+#     access_log /var/www/logs/csss-site-backend/test-nginx-access.log;
+#     error_log /var/www/logs/csss-site-backend/test-nginx-error.log;
+#
+#     error_page 404 /404.html;
+#
+#     # proxy csss-site-backend
+#     location /api/ {
+#         rewrite ^/api/(.*)$ /$1 break;
+#
+#         keepalive_timeout 5;
+#         client_max_body_size 1G; # Was 4G
+#
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#         proxy_pass http://backend;
+#
+#         # update cors header to allow requests from test site
+#         add_header Access-Control-Allow-Origin https://test.sfucsss.org always;
+#         add_header Access-Control-Allow-Credentials true;
+#     }
+#
+#     # Events had a URL scheme like `sfucsss.org/events/<event>/<year>[/page]`
+#     # We want to redirect them to `<event>.sfucsss.org/<year>[/page]`
+#     location ~ "^/events/(mm|mountain_madness)/(?<year>\d{4})(?<page>/.*)$" {
+#         return 301 https://madness.sfucsss.org/$year$page;
+#     }
+#
+#     # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
+#     location ~ "^/events/(?<event>tech-fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
+#         set $new_event "";
+#         if ($event = "tech_fair") {
+#             set $new_event "tech-fair";
+#         }
+#         if ($event = "fall_hacks") {
+#             set $new_event "fall-hacks";
+#         }
+#         return 301 /events/$new_event/$year$page;
+#     }
+#
+#     # for the rest of the subdomains
+#     location ~ "^/events/(?<event>frosh|tech-fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
+#         return 301 https://$event.sfucsss.org/$year$page;
+#     }
+#
+#     location / {
+#         charset utf-8;
+#         try_files $uri $uri/ $uri.html $uri/index.html =404;
+#     }
+# }
 
 # TODO: Figure out how to do a wildcard domain
 # Serves the event pages
@@ -240,38 +140,51 @@ server {
     }
 
     location / {
-        # TODO: When the rest of the static pages are migrated, uncomment the next line
-        # root /var/www/html/frosh/latest;
+        root /var/www/html/tech-fair/latest;
         try_files $uri $uri/ /index.html =404;
     }
 }
 
-# TODO: Uncomment this when Fall Hacks A record made
-# server {
-#     server_name fall-hacks.sfucsss.org
-#     listen 80;
-#
-#     root /var/www/html;
-#
-#     location / {
-#         try_files /404.html =404;
-#     }
-# }
+server {
+    server_name fall-hacks.sfucsss.org
+    listen 80;
 
-# TODO: Uncomment this when Madness A record made
-# server {
-#     server_name madness.sfucsss.org
-#     listen 80;
-#
-#     root /var/www/html;
-#
-#     location / {
-#         try_files /404.html =404;
-#     }
-# }
+    root /var/www/html/fall-hacks;
 
-# TODO: Comment this block out if there are no pages under construction.
-# For pages under construction
+    location /static/ {
+        alias /var/www/html/static;
+    }
+
+    location ~ "^/(?<year>\d{4})(/.*)?$" {
+        try_files $uri $uri/ $year/index.html;
+    }
+
+    location / {
+        root /var/www/html/fall-hacks/latest;
+        try_files $uri $uri/ /index.html =404;
+    }
+}
+
+server {
+    server_name madness.sfucsss.org
+    listen 80;
+
+    root /var/www/html/madness;
+
+    location /static/ {
+        alias /var/www/html/static;
+    }
+
+    location ~ "^/(?<year>\d{4})(/.*)?$" {
+        try_files $uri $uri/ $year/index.html;
+    }
+
+    location / {
+        root /var/www/html/madness/latest;
+        try_files $uri $uri/ /index.html =404;
+    }
+}
+
 server {
     server_name www.sfucsss.org sfucsss.org;
     listen 80;
@@ -281,12 +194,69 @@ server {
     access_log /var/www/logs/csss-site-backend/nginx-access.log;
     error_log /var/www/logs/csss-site-backend/nginx-error.log;
 
-    location ~* .(css|webp|png|svg) {
-        try_files $uri =404;
+    # proxy csss-site-backend
+    location /api/ {
+        rewrite ^/api/(.*)$ /$1 break;
+
+        keepalive_timeout 5;
+        client_max_body_size 1G; # Was 4G
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://backend;
+
+        add_header Access-Control-Allow-Origin https://sfucsss.org always;
+        add_header Access-Control-Allow-Credentials true;
+    }
+
+    # Events had a URL scheme like `sfucsss.org/events/<event>/<year>[/page]`
+    # We want to redirect them to `<event>.sfucsss.org/<year>[/page]`
+    location ~ "^/events/(mm|mountain_madness)/(?<year>\d{4})(?<page>/.*)$" {
+        return 301 https://madness.sfucsss.org/$year$page;
+    }
+
+    # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
+    location ~ "^/events/(?<event>tech_fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
+        set $new_event "";
+        if ($event = "tech_fair") {
+            set $new_event "tech-fair";
+        }
+        if ($event = "fall_hacks") {
+            set $new_event "fall-hacks";
+        }
+        return 301 /events/$new_event/$year$page;
+    }
+
+    # for the rest of the subdomains
+    location ~ "^/events/(?<event>frosh|tech-fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
+        return 301 https://$event.sfucsss.org/$year$page;
     }
 
     location / {
         charset utf-8;
-        try_files /construction.html =503;
+        # Main site is a SPA, so we always serve the main Angular application
+        try_files $uri $uri/ $uri.html $uri/index.html;
     }
 }
+
+# For pages under construction
+# server {
+#     server_name www.sfucsss.org sfucsss.org;
+#     listen 80;
+#
+#     root /var/www/html;
+#
+#     access_log /var/www/logs/csss-site-backend/nginx-access.log;
+#     error_log /var/www/logs/csss-site-backend/nginx-error.log;
+#
+#     location ~* .(css|webp|png|svg) {
+#         try_files $uri =404;
+#     }
+#
+#     location / {
+#         charset utf-8;
+#         try_files /construction.html =503;
+#     }
+# }


### PR DESCRIPTION
closes #17 

* Server block for `sfucsss.org` should serve the main Angular
  application
* Added a redirect from `new` subdomain to the base domain
* Disabled the `test` subdomain as it contains no new changes
* Completed the server blocks for `madness` and `fall-hacks`
* Disabled the "Under Construction" server block
* Added redirects from the old URL schema from the main site to the
  subdomains: /events/<event>/<year> -> <event>.sfucsss.org/<year>
* Subdomains will redirect to the `.../<event>/latest` directory for
  events URLs that don't specify a year
* Updated the frontend submodule to use the main site's build