### PR TITLE
Fix: Direct SPA routing and Event page subpages send 500s

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,7 @@ upstream backend {
 
 # Redirect from the first rewrite to the Angular rewrite
 server {
-    server_name www.new.sfucsss.org new.sfucsss.org;
+    server_name new.sfucsss.org;
     listen 80;
     return 301 $scheme://sfucsss.org$request_uri;
 }
@@ -115,7 +115,7 @@ server {
     }
 
     location ~ "^/(?<year>\d{4})(/.*)?$" {
-        try_files $uri $uri/ $year/index.html;
+        try_files $uri $uri/ $uri.html $year/index.html =404;
     }
 
     location / {
@@ -136,7 +136,7 @@ server {
     }
 
     location ~ "^/(?<year>\d{4})(/.*)?$" {
-        try_files $uri $uri/ $year/index.html;
+        try_files $uri $uri/ $uri.html $year/index.html =404;
     }
 
     location / {
@@ -156,7 +156,7 @@ server {
     }
 
     location ~ "^/(?<year>\d{4})(/.*)?$" {
-        try_files $uri $uri/ $year/index.html;
+        try_files $uri $uri/ $uri.html $year/index.html =404;
     }
 
     location / {
@@ -176,7 +176,7 @@ server {
     }
 
     location ~ "^/(?<year>\d{4})(/.*)?$" {
-        try_files $uri $uri/ $year/index.html;
+        try_files $uri $uri/ $uri.html $year/index.html =404;
     }
 
     location / {
@@ -186,7 +186,7 @@ server {
 }
 
 server {
-    server_name www.sfucsss.org sfucsss.org;
+    server_name sfucsss.org;
     listen 80;
 
     root /var/www/html;
@@ -237,7 +237,7 @@ server {
     location / {
         charset utf-8;
         # Main site is a SPA, so we always serve the main Angular application
-        try_files $uri $uri/ $uri.html $uri/index.html;
+        try_files $uri $uri/ /index.html;
     }
 }
 


### PR DESCRIPTION
* Direct routes on the nginx config would send a 500 because instead of sending back the SPA index, they would attempt to find the `$uri.html` file first, which didn't exist
* Events pages would 404 because the subpages are not named `<subpage>/index.html`, but just `<subpage>.html`, so the HTML file didn't exist
* Removed the subdomains that used `www` since we don't have those registered