### PR TITLE
Fix: Redirects from old site and new site

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -218,7 +218,7 @@ server {
     }
 
     # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
-    location ~ "^/events/(?<event>tech_fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
+    location ~ "^/events/(?<event>tech_fair|fall-hacks)(?<year>/\d{4})?(?<page>/.*)?$" {
         set $new_event "";
         if ($event = "tech_fair") {
             set $new_event "tech-fair";
@@ -226,12 +226,12 @@ server {
         if ($event = "fall_hacks") {
             set $new_event "fall-hacks";
         }
-        return 301 /events/$new_event/$year$page;
+        return 301 /events/$new_event$year$page;
     }
 
     # for the rest of the subdomains
-    location ~ "^/events/(?<event>frosh|tech-fair|fall-hacks)/(?<year>\d{4})(?<page>/.*)?$" {
-        return 301 https://$event.sfucsss.org/$year$page;
+    location ~ "^/events/(?<event>frosh|tech-fair|fall-hacks)(?<year>/\d{4})(?<page>/.*)?$" {
+        return 301 https://$event.sfucsss.org$year$page;
     }
 
     location / {

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,13 +2,6 @@ upstream backend {
     server unix:/var/www/gunicorn.sock fail_timeout=0;
 }
 
-# Redirect from the first rewrite to the Angular rewrite
-server {
-    server_name new.sfucsss.org;
-    listen 80;
-    return 301 $scheme://sfucsss.org$request_uri;
-}
-
 # suitable for testing new deployments
 # server {
 #     server_name test.sfucsss.org;
@@ -185,6 +178,38 @@ server {
     }
 }
 
+# Redirect from the first rewrite to the Angular rewrite
+server {
+    server_name new.sfucsss.org;
+    listen 80;
+
+    # Events had a URL scheme like `new.sfucsss.org[/events]/<event>/<year>[/<page>]`
+    # We want to redirect them to `<event>.sfucsss.org[/<year>][/<page>]`
+    location ~ "^(/events)?/(mm|mountain_madness)(?<year>/\d{4})(?<page>/.*)$" {
+        return 301 https://madness.sfucsss.org$year$page;
+    }
+
+    # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
+    location ~ "^/events/(?<event>tech_fair|fall-hacks)(?<year>/\d{4})?(?<page>/.*)?$" {
+        set $new_event "";
+        if ($event = "tech_fair") {
+            set $new_event "tech-fair";
+        }
+        if ($event = "fall_hacks") {
+            set $new_event "fall-hacks";
+        }
+        return 301 https://$new_event.sfucsss.org$year$page;
+    }
+
+    # for the rest of the subdomains
+    location ~ "^/events/(?<event>frosh|tech-fair|fall-hacks)(?<year>/\d{4})(?<page>/.*)?$" {
+        return 301 https://$event.sfucsss.org$year$page;
+    }
+
+    return 301 $scheme://sfucsss.org$request_uri;
+}
+
+
 server {
     server_name sfucsss.org;
     listen 80;
@@ -211,8 +236,8 @@ server {
         add_header Access-Control-Allow-Credentials true;
     }
 
-    # Events had a URL scheme like `sfucsss.org/events/<event>/<year>[/page]`
-    # We want to redirect them to `<event>.sfucsss.org/<year>[/page]`
+    # Events had a URL scheme like `sfucsss.org/<event>/<year>[/<page>]`
+    # We want to redirect them to `<event>.sfucsss.org[/<year>][/<page>]`
     location ~ "^/events/(mm|mountain_madness)/(?<year>\d{4})(?<page>/.*)$" {
         return 301 https://madness.sfucsss.org/$year$page;
     }


### PR DESCRIPTION
* Fixed redirects from `/events/<event>` that had no year after `<event>`
* Fixed redirects from `new.sfucsss.org/<event>/<year>`