### PR TITLE
Fix: broken link forwarding

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -243,7 +243,7 @@ server {
     }
 
     # Since they used underscores before, we'll need to redirect URLs to the hyphenated version
-    location ~ "^/events/(?<event>tech_fair|fall-hacks)(?<year>/\d{4})?(?<page>/.*)?$" {
+    location ~ "^/events/(?<event>tech_fair|fall_hacks)(?<year>/\d{4})?(?<page>/.*)?$" {
         set $new_event "";
         if ($event = "tech_fair") {
             set $new_event "tech-fair";
@@ -251,7 +251,7 @@ server {
         if ($event = "fall_hacks") {
             set $new_event "fall-hacks";
         }
-        return 301 /events/$new_event$year$page;
+        return 301 https://$new_event.sfucsss.org$year$page;
     }
 
     # for the rest of the subdomains


### PR DESCRIPTION
closes #35 

Issue:
When using old event URLs from the event pages that used underscores (tech_fair and fall_hacks) redirects would go to the main site, which would 404 since that route doesn't exist.

Root cause:
Redirects for the hyphenated versions redirected to the proper subdomain, while the underscore versions would redirect to the hyphenated URL version. This was not caught by the hyphenated redirects, so it resulted in going the main site onto route that didn't exist.

Solution:
Change the redirect strategy of the underscore versions to redirect to the directly to the subdomain.